### PR TITLE
Fix 500 error on dashboard when JWT token has expired

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -104,7 +104,15 @@ class CSPNonceMiddleware(BaseHTTPMiddleware):
         # Generate nonce and store in request state
         request.state.nonce = secrets.token_urlsafe(16)
 
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except gel.errors.QueryAssertionError as exc:
+            if "JWT is expired" in str(exc):
+                logger.warning("Expired JWT detected, redirecting to signin")
+                response = RedirectResponse(url="/auth/ui/signin", status_code=302)
+                response.delete_cookie("gel-auth-token", path="/")
+                return response
+            raise
 
         # Apply CSP header
         nonce = request.state.nonce


### PR DESCRIPTION
When users return after being away, their JWT expires but the stale
cookie remains. The database query fails with QueryAssertionError
instead of gracefully handling the expired session. Now the middleware
catches this error, clears the stale cookie, and redirects to signin.

https://claude.ai/code/session_01DJ3ncSoKdiiN3sCEscRB2q